### PR TITLE
Fix WebinarKit customField1 receiving $NaN for $100,000+ option

### DIFF
--- a/src/pages/api/webinar-registration.ts
+++ b/src/pages/api/webinar-registration.ts
@@ -494,9 +494,13 @@ export const POST: APIRoute = async ({ request, locals }) => {
       fullDate: body.fullDate, // Human-readable datetime for display
       // Analytics and segmentation fields for WebinarKit CSV export
       source: body?.utm?.utm_source || "direct",
-      customField1: body.invest_intent
-        ? `$${Number(body.invest_intent).toLocaleString("en-US", { minimumFractionDigits: 2 })}`
-        : "",
+      customField1: (() => {
+        if (!body.invest_intent) return "";
+        const n = Number(String(body.invest_intent).replace(/[^\d.]/g, ""));
+        return isNaN(n) || n === 0
+          ? ""
+          : `$${n.toLocaleString("en-US", { minimumFractionDigits: 2 })}`;
+      })(),
       customField2: utmCampaignFinal,
       customField3: body?.utm?.utm_content || "",
       customField4: body?.utm?.utm_adgroup || body?.google_adgroup_id || "",


### PR DESCRIPTION
## Summary
- `Number("100000+")` returns `NaN`, sending `"$NaN"` to WebinarKit's custom field 1 for users selecting the `$100,000+` tier
- Strip non-digit/dot characters before numeric coercion so the value renders as `$100,000.00`
- Confirmed in WebinarKit registrant export: multiple recent registrants show `$NaN` in custom field 1

## Test plan
- [ ] Submit webinar form with `$100,000+` option, confirm WebinarKit custom field 1 shows `$100,000.00`
- [ ] Submit with `$10,000` option, confirm unchanged behavior
- [ ] Submit with no investment selected, confirm empty string

🤖 Generated with [Claude Code](https://claude.com/claude-code)